### PR TITLE
Comment added to terraform.tfvars.example to show how to lookup F5 BIG-IP VE ami's.

### DIFF
--- a/terraform-aws-sslo/terraform.tfvars.example
+++ b/terraform-aws-sslo/terraform.tfvars.example
@@ -46,6 +46,12 @@ instance_type = "m5.4xlarge"
 # AMI IDs (Region-specific)
 inspection_ami = "ami-0cdc9ccb73322825f" ### us-east-1 ### Snort pre-configured by Miri Infotech Inc. on Ubuntu
 webapp_ami     = "ami-05343502b4149e010" ### us-east-1 ### WordPress with NGINX and SSL Certified by Bitnami and Automattic
+
+# The default BIG-IP VE versions below were tested and confirmed to work.
+# To deploy a different version, lookup the ami for your aws region first. For example:
+# aws ec2 describe-images --region us-east-1 \
+#   --filters Name=name,Values=*BIGIP-15.1.5*2Boot* \
+#   | jq '.Images[] |.ImageId, .Name'
 sslo_ami       = "ami-06ceb79f3482bd83c" ### us-east-1 ### F5 BIG-IP VE - ALL (BYOL, 2 Boot Locations) ### 15.1.1 (SSLO 7.5)
 #sslo_ami       = "ami-xxxxxxxxxxxxxxxxx" ### us-east-1 ### F5 BIG-IP VE - ALL (BYOL, 2 Boot Locations) ### 16.1.0 (SSLO 9.0)
 


### PR DESCRIPTION
Not meant to encourage trying different versions, but to reduce the burden to maintain a 'fresh' version in the terraform code.